### PR TITLE
[SyntaxSupport]: Adding support for enum type with no assignments and variable declarations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,6 @@ FetchContent_MakeAvailable(fmt)
 
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-add_executable(test test.cpp)
-target_link_libraries(test PRIVATE fmt::fmt)
-
-
-
 add_subdirectory(lib)
 add_subdirectory(tests)
 # add_subdirectory(tools)

--- a/include/FrontEnd/AST/AST.hpp
+++ b/include/FrontEnd/AST/AST.hpp
@@ -11,6 +11,7 @@
 
 #include "FrontEnd/Lexer/Token.hpp"
 #include "FrontEnd/AST/Type.hpp"
+#include "FrontEnd/Parser/Parser.hpp"
 #include "Utils/ErrorLogger.hpp"
 
 class Value;
@@ -96,6 +97,26 @@ class MemberDeclaration : public Statement
   private:
     std::string Name;
     Type AType;
+};
+
+class EnumDeclaration : public Statement
+{
+  public:
+    using EnumList = std::vector<std::pair<std::string, int>>;
+
+  public:
+    EnumDeclaration(Type &BT, EnumList Enumerators)
+        : BaseType(BT), Enumerators(std::move(Enumerators))
+    {}
+
+    EnumDeclaration(EnumList Enumerators) : Enumerators(std::move(Enumerators)) {}
+
+    void ASTDump(unsigned tab = 0) override;
+    Value *IRCodegen(IRFactory *IRF) override;
+
+  private:
+    Type BaseType {Type::Int};
+    EnumList Enumerators;
 };
 
 class StructDeclaration : public Statement
@@ -387,9 +408,7 @@ class UnaryExpression : public Expression
     using ExprPtr = std::unique_ptr<Expression>;
 
   public:
-    enum UnaryOperation {
-        DeRef
-    };
+    enum UnaryOperation { DeRef };
 
     UnaryExpression() = default;
     UnaryExpression(Token Op, ExprPtr E);

--- a/include/FrontEnd/AST/Type.hpp
+++ b/include/FrontEnd/AST/Type.hpp
@@ -21,11 +21,7 @@ class Type
         Double,
     };
 
-    enum TypeKind {
-        Simple,
-        Array,
-        Struct
-    };
+    enum TypeKind { Simple, Array, Struct };
 
     Type() : Kind(Simple), Ty(Invalid) {};
     Type(VariantKind vk) : Ty(vk), Kind(Simple) {}
@@ -110,25 +106,13 @@ class ValueType
     bool IsFloat() { return Kind == Float; }
     bool IsEmpty() { return Kind == Empty; }
 
-    unsigned GetIntVal()
-    {
-        assert(IsInt() && "Must be an integer type.");
-        return IntVal;
-    }
-    double GetFloatVal()
-    {
-        assert(IsFloat() && "Must be a float type.");
-        return FloatVal;
-    }
+    int GetIntVal();
+    double GetFloatVal();
 
     friend bool operator==(const ValueType &lhs, const ValueType &rhs);
 
   private:
-    enum ValueKind {
-        Empty,
-        Integer,
-        Float
-    };
+    enum ValueKind { Empty, Integer, Float };
     ValueKind Kind;
     union
     {

--- a/include/FrontEnd/Parser/Parser.hpp
+++ b/include/FrontEnd/Parser/Parser.hpp
@@ -16,6 +16,7 @@ class Declaration;
 class VariableDeclaration;
 class MemberDeclaration;
 class StructDeclaration;
+class EnumDeclaration;
 class FunctionDeclaration;
 class FunctionParameterDeclaration;
 
@@ -61,6 +62,7 @@ class Parser
     std::vector<std::unique_ptr<FunctionParameterDeclaration>> ParseParameterList();
     std::unique_ptr<MemberDeclaration> ParseMemberDeclaration();
     std::unique_ptr<StructDeclaration> ParseStructDeclaration();
+    std::unique_ptr<EnumDeclaration> ParseEnumDeclaration();
 
     Type ParseTypeSpecifier();
     Node ParseReturnTypeSpecifier();

--- a/lib/FrontEnd/AST/AST.cpp
+++ b/lib/FrontEnd/AST/AST.cpp
@@ -333,6 +333,8 @@ Value *MemberDeclaration::IRCodegen(IRFactory *IRF) { return nullptr; }
 
 Value *StructDeclaration::IRCodegen(IRFactory *IRF) { return nullptr; }
 
+Value *EnumDeclaration::IRCodegen(IRFactory *IRF) { return nullptr; }
+
 Value *CallExpression::IRCodegen(IRFactory *IRF)
 {
     std::vector<Value *> Args;
@@ -687,6 +689,24 @@ void StructDeclaration::ASTDump(unsigned tab)
         M->ASTDump(tab + 2);
 }
 
+void EnumDeclaration::ASTDump(unsigned tab)
+{
+    auto HeaderStr      = fmt::format("EnumDeclaration `{}`", BaseType.ToString());
+    std::string BodyStr = "Enumerators ";
+
+    std::size_t LoopCounter = 0;
+    for (auto &[Enum, Val] : Enumerators)
+    {
+        BodyStr += fmt::format("`{}` = {}", Enum, Val);
+
+        if (++LoopCounter < Enumerators.size())
+            BodyStr += ", ";
+    }
+
+    PrintLn(HeaderStr.c_str(), tab);
+    PrintLn(BodyStr.c_str(), tab + 2);
+}
+
 void CompoundStatement::ASTDump(unsigned int tab)
 {
     PrintLn("CompoundStatement ", tab);
@@ -711,7 +731,9 @@ void IfStatement::ASTDump(unsigned int tab)
 
     Condition->ASTDump(tab + 2);
     IfBody->ASTDump(tab + 2);
-    ElseBody->ASTDump(tab + 2);
+
+    if (ElseBody)
+        ElseBody->ASTDump(tab + 2);
 }
 
 void WhileStatement::ASTDump(unsigned int tab)

--- a/lib/FrontEnd/AST/Type.cpp
+++ b/lib/FrontEnd/AST/Type.cpp
@@ -9,13 +9,10 @@ Type::Type(Type::TypeKind tk) : Kind(tk)
     switch (tk)
     {
         case Array:
-        case Struct:
-            Ty = Composite;
-            break;
+        case Struct: Ty = Composite; break;
+
         case Simple:
-        default:
-            Ty = Invalid;
-            break;
+        default: Ty = Invalid; break;
     }
 }
 
@@ -81,21 +78,14 @@ std::string Type::ToString(const Type &t)
 {
     switch (t.GetTypeVariant())
     {
-        case Double:
-            return "double";
-        case Int:
-            return "int";
-        case Char:
-            return "char";
-        case Void:
-            return "void";
-        case Composite:
-            return t.GetName();
-        case Invalid:
-            return "invalid";
-        default:
-            assert(false && "Unknown type.");
-            break;
+        case Double: return "double";
+        case Int: return "int";
+        case Char: return "char";
+        case Void: return "void";
+        case Composite: return t.GetName();
+        case Invalid: return "invalid";
+
+        default: assert(false && "Unknown type."); break;
     }
 }
 
@@ -147,13 +137,22 @@ bool operator==(const Type &lhs, const Type &rhs)
 
     switch (lhs.Kind)
     {
-        case Type::Array:
-            result = result && (lhs.Dimensions == rhs.Dimensions);
-            break;
-        default:
-            break;
+        case Type::Array: result = result && (lhs.Dimensions == rhs.Dimensions); break;
+        default: break;
     }
     return result;
+}
+
+int ValueType::GetIntVal()
+{
+    assert(IsInt() && "Must be an integer type.");
+    return IntVal;
+}
+
+double ValueType::GetFloatVal()
+{
+    assert(IsFloat() && "Must be a float type.");
+    return FloatVal;
 }
 
 bool operator==(const ValueType &lhs, const ValueType &rhs)
@@ -165,14 +164,9 @@ bool operator==(const ValueType &lhs, const ValueType &rhs)
 
     switch (lhs.Kind)
     {
-        case ValueType::Integer:
-            result = result && (lhs.IntVal == rhs.IntVal);
-            break;
-        case ValueType::Float:
-            result = result && (lhs.FloatVal == rhs.FloatVal);
-            break;
-        default:
-            break;
+        case ValueType::Integer: result = result && (lhs.IntVal == rhs.IntVal); break;
+        case ValueType::Float: result = result && (lhs.FloatVal == rhs.FloatVal); break;
+        default: break;
     }
     return result;
 }

--- a/lib/FrontEnd/Lexer/Lexer.cpp
+++ b/lib/FrontEnd/Lexer/Lexer.cpp
@@ -13,6 +13,7 @@ std::unordered_map<std::string, Token::TokenKind> Lexer::KeyWords =
         {"while",  Token::While },
         {"return", Token::Return},
         {"struct", Token::Struct},
+        {"enum",   Token::Enum  },
 };
 
 Lexer::Lexer(std::vector<std::string> &s)
@@ -152,21 +153,11 @@ std::optional<Token> Lexer::LexSymbol()
 
     switch (GetNextChar())
     {
-        case '.':
-            TokenKind = Token::Dot;
-            break;
-        case ',':
-            TokenKind = Token::Comma;
-            break;
-        case '+':
-            TokenKind = Token::Plus;
-            break;
-        case '-':
-            TokenKind = Token::Minus;
-            break;
-        case '*':
-            TokenKind = Token::Mul;
-            break;
+        case '.': TokenKind = Token::Dot; break;
+        case ',': TokenKind = Token::Comma; break;
+        case '+': TokenKind = Token::Plus; break;
+        case '-': TokenKind = Token::Minus; break;
+        case '*': TokenKind = Token::Mul; break;
         case '/':
             if (GetNextNthCharOnSameLine(1) == '/')
             {
@@ -178,9 +169,7 @@ std::optional<Token> Lexer::LexSymbol()
                 TokenKind = Token::Div;
             }
             break;
-        case '%':
-            TokenKind = Token::Mod;
-            break;
+        case '%': TokenKind = Token::Mod; break;
         case '=':
             if (GetNextNthCharOnSameLine(1) == '=')
             {
@@ -192,12 +181,8 @@ std::optional<Token> Lexer::LexSymbol()
                 TokenKind = Token::Assign;
             }
             break;
-        case '<':
-            TokenKind = Token::Less;
-            break;
-        case '>':
-            TokenKind = Token::Greater;
-            break;
+        case '<': TokenKind = Token::Less; break;
+        case '>': TokenKind = Token::Greater; break;
         case '!':
             if (GetNextNthCharOnSameLine(1) == '=')
             {
@@ -220,29 +205,14 @@ std::optional<Token> Lexer::LexSymbol()
                 TokenKind = Token::And;
             }
             break;
-        case ';':
-            TokenKind = Token::SemiColon;
-            break;
-        case '(':
-            TokenKind = Token::LeftParen;
-            break;
-        case ')':
-            TokenKind = Token::RightParen;
-            break;
-        case '[':
-            TokenKind = Token::LeftBracket;
-            break;
-        case ']':
-            TokenKind = Token::RightBracket;
-            break;
-        case '{':
-            TokenKind = Token::LeftBrace;
-            break;
-        case '}':
-            TokenKind = Token::RightBrace;
-            break;
-        default:
-            return std::nullopt;
+        case ';': TokenKind = Token::SemiColon; break;
+        case '(': TokenKind = Token::LeftParen; break;
+        case ')': TokenKind = Token::RightParen; break;
+        case '[': TokenKind = Token::LeftBracket; break;
+        case ']': TokenKind = Token::RightBracket; break;
+        case '{': TokenKind = Token::LeftBrace; break;
+        case '}': TokenKind = Token::RightBrace; break;
+        default: return std::nullopt;
     }
 
     std::string_view StringValue {&Source[LineIndex][ColumnIndex], Size};

--- a/lib/FrontEnd/Lexer/Token.cpp
+++ b/lib/FrontEnd/Lexer/Token.cpp
@@ -56,6 +56,7 @@ const std::unordered_map<Token::TokenKind, std::string> Token::Token2Str = {
     {Void,          "void"       },
     {Char,          "char"       },
     {Struct,        "struct"     },
+    {Enum,          "enum"       },
 };
 
 std::string Token::ToString(Token::TokenKind tk)

--- a/lib/FrontEnd/Parser/Parser.cpp
+++ b/lib/FrontEnd/Parser/Parser.cpp
@@ -181,11 +181,19 @@ std::unique_ptr<Node> Parser::ParseExternalDeclaration()
     std::unique_ptr<TranslationUnit> TU = std::make_unique<TranslationUnit>();
     auto TokenKind                      = GetCurrentTokenKind();
 
-    while (IsReturnTypeSpecifier(TokenKind) || lexer.Is(Token::Struct))
+    while (IsReturnTypeSpecifier(TokenKind) || lexer.Is(Token::Struct)
+           || lexer.Is(Token::Enum))
     {
         if (lexer.Is(Token::Struct) && lexer.LookAhead(3).GetKind() == Token::LeftBrace)
         {
             TU->AddDeclaration(ParseStructDeclaration());
+            TokenKind = GetCurrentTokenKind();
+            continue;
+        }
+
+        if (lexer.Is(Token::Enum))
+        {
+            TU->AddDeclaration(ParseEnumDeclaration());
             TokenKind = GetCurrentTokenKind();
             continue;
         }
@@ -415,6 +423,40 @@ std::unique_ptr<StructDeclaration> Parser::ParseStructDeclaration()
 
     return std::make_unique<StructDeclaration>(Name, Members, type);
 }
+
+// <EnumDeclaration> ::= 'enum' '{' <Identifier> (, <Identifier>)* '}' ';'
+std::unique_ptr<EnumDeclaration> Parser::ParseEnumDeclaration()
+{
+    Expect(Token::Enum);
+    Expect(Token::LeftBrace);
+
+    EnumDeclaration::EnumList Enumerators;
+
+    int EnumCounter = 0;
+    do
+    {
+        if (lexer.Is(Token::Comma))
+            Lex();
+
+        auto Identifier = Expect(Token::Identifier);
+        Enumerators.push_back({Identifier.GetString(), EnumCounter});
+
+        // Insert into the symbol table and for now assign the index of the enum
+        // to it, not considering explicit assignments like "enum { A = 10 };"
+        InsertToSymbolTable(Identifier.GetString(),
+                            Type(Type::Int),
+                            false,
+                            ValueType((unsigned)EnumCounter));
+        EnumCounter++;
+    }
+    while (lexer.Is(Token::Comma));
+
+    Expect(Token::RightBrace);
+    Expect(Token::SemiColon);
+
+    return std::make_unique<EnumDeclaration>(Enumerators);
+}
+
 
 //=--------------------------------------------------------------------------=//
 //=------------------------- Parse Statement --------------------------------=//
@@ -696,6 +738,13 @@ std::unique_ptr<Expression> Parser::ParseIdentifierExpression()
 
     if (auto SymEntry = SymTabStack.Contains(IdStr))
     {
+        // If the symbol value is a know constant like in case of enumerators, then
+        // return just a constant expression
+        // TODO: Maybe do ths check earlier to save ourself from creating RE for
+        // nothing
+        if (auto Val = std::get<2>(SymEntry.value()); !Val.IsEmpty())
+            return std::make_unique<IntegerLiteralExpression>(Val.GetIntVal());
+
         auto Ty = std::get<1>(SymEntry.value());
         RE->SetResultType(Ty);
     }


### PR DESCRIPTION
For now it is only allowed as top level declaration with no assignments and variable declarations.
Example:
     `enum {A, B, C};`