### PR TITLE
[BackEnd/AArch64]: Adding support for truncating 64 bit regs to 32 bt regs.

### DIFF
--- a/lib/BackEnd/TargetArchs/AArch64/AArch64TargetMachine.cpp
+++ b/lib/BackEnd/TargetArchs/AArch64/AArch64TargetMachine.cpp
@@ -247,6 +247,21 @@ bool AArch64TargetMachine::SelectTrunc(MachineInstruction *MI)
         return true;
     }
 
+    // in cases like
+    //      TRUNC  %dst(s32), %src(s64)
+    // for arm only a "mov" instruction is needed, but for $src the W subregister
+    // of the X register should be used, this will be enforced in a later pass
+    if (MI->GetOperand(0)->GetType().GetBitWidth() == 32 &&
+        MI->GetOperand(1)->GetType().GetBitWidth() == 64)
+    {
+        if (!MI->GetOperand(1)->IsImmediate())
+        {
+            MI->SetOpcode(MOV_rr);
+            return true;
+        }
+    }
+
+    assert(!"Unimplemented");
     return false;
 }
 

--- a/lib/FrontEnd/AST/AST.cpp
+++ b/lib/FrontEnd/AST/AST.cpp
@@ -722,6 +722,10 @@ Value *CallExpression::IRCodegen(IRFactory *IRF)
     {
         case Type::Int: ReturnIRType = IRType(IRType::SInt); break;
         case Type::UnsignedInt: ReturnIRType = IRType(IRType::UInt); break;
+        case Type::Long: ReturnIRType = IRType(IRType::SInt, 64); break;
+        case Type::UnsignedLong: ReturnIRType = IRType(IRType::UInt, 64); break;
+        case Type::LongLong: ReturnIRType = IRType(IRType::SInt, 64); break;
+        case Type::UnsignedLongLong: ReturnIRType = IRType(IRType::UInt, 64); break;
         case Type::Double: ReturnIRType = IRType(IRType::FP, 64); break;
         case Type::Void: ReturnIRType = IRType(IRType::None, 0); break;
         case Type::Composite: {
@@ -758,8 +762,10 @@ Value *CallExpression::IRCodegen(IRFactory *IRF)
 
             break;
         }
-        default: break;
+        default: assert(!"Unreachable"); break;
     }
+
+    assert(!ReturnIRType.IsInvalid() && "Must be a valid type.");
 
     // in case if the ret type was a struct, so StructTemp not nullptr
     if (StructTemp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,12 +39,12 @@ add_executable(
   ../lib/BackEnd/TargetArchs/AArch64/AArch64TargetABI.cpp
   ../lib/BackEnd/TargetArchs/AArch64/AArch64TargetMachine.cpp
   ../lib/BackEnd/TargetArchs/AArch64/AArch64RegisterInfo.cpp
+  ../lib/BackEnd/TargetArchs/AArch64/AArch64MovFixPass.cpp
   ../lib/BackEnd/TargetArchs/AArch64/AArch64InstructionLegalizer.cpp
   ../lib/BackEnd/TargetArchs/AArch64/AArch64InstructionDefinitions.cpp
   ../lib/BackEnd/TargetArchs/RISCV/RISCVRegisterInfo.cpp
   ../lib/BackEnd/TargetArchs/RISCV/RISCVInstructionDefinitions.cpp
   ../lib/BackEnd/TargetArchs/RISCV/RISCVTargetABI.cpp
-  ../lib/BackEnd/TargetArchs/RISCV/RISCVTargetMachine.cpp
-)
+  ../lib/BackEnd/TargetArchs/RISCV/RISCVTargetMachine.cpp)
 
 target_link_libraries(LunarTcc PRIVATE fmt::fmt)

--- a/tests/frontendTest.cpp
+++ b/tests/frontendTest.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <fmt/core.h>
 #include <fmt/color.h>
+#include "BackEnd/TargetArchs/AArch64/AArch64MovFixPass.hpp"
 #include "Utils/ErrorLogger.hpp"
 #include "BackEnd/MachineIRModule.hpp"
 #include "FrontEnd/Lexer/Lexer.hpp"
@@ -204,6 +205,9 @@ int main(int argc, char *argv[])
 
     PrologueEpilogInsertion PEI(&LLIRModule, TM.get());
     PEI.Run();
+
+    if (TargetArch == "aarch64")
+        AArch64MovFixPass(&LLIRModule, TM.get()).Run();
 
     if (PrintBeforePasses)
     {


### PR DESCRIPTION
Implemented by selecting Mov for it and adding an extra pass which will change MOV's source operand to its W-subreg if it was X-Reg (This step is a bit redundant, optimize it later)